### PR TITLE
Update play-sound.el

### DIFF
--- a/play-sound.el
+++ b/play-sound.el
@@ -32,7 +32,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defun play-sound-internal (sound)
   "Internal function for `play-sound' (which see)."


### PR DESCRIPTION
added the newer cl-lib in lieu of the old deprecated cl library.

tested on my macbook pro M1 pro and it works now. 